### PR TITLE
fix: align /v5/broker/earnings-info params with official docs; bump t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.6.0 — 2026-08-07
+
+### Fixed — Broker Earnings Info
+- `getBrokerEarningData` (`GET /v5/broker/earnings-info`) parameters aligned with the official docs:
+  - `startTime` (Long) → `begin` (String, `YYYYMMDD`)
+  - `endTime` (Long) → `end` (String, `YYYYMMDD`)
+  - Added `uid` (String) — filter earnings by a specific sub UID
+  - Javadoc / response fields updated to reflect the latest schema
+    (`totalEarningCat`, `markupEarning`, `baseFeeEarning`, `execId`, `CONVERT` bizType)
+
+### Breaking Changes
+- `BybitApiService#getBrokerEarningData` signature changed. Callers using
+  `BrokerDataRequest#setStartTime` / `setEndTime` for this endpoint must switch to
+  the new `begin` / `end` / `uid` fields on `BrokerDataRequest`.
+  (`startTime` / `endTime` remain in `BrokerDataRequest` for other broker endpoints.)
+
 ## 1.5.0 — 2026-07-09
 
 ### Added — New Clients

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Maven Example
 <dependency>
     <groupId>io.github.johnnywic</groupId>
     <artifactId>bybit-java-api</artifactId>
-    <version>1.4.0</version>
+    <version>1.6.0</version>
 </dependency>
 ```
 Gradle Example
 ```java
-implementation group: 'io.github.johnnywic', name: 'bybit-java-api', version: '1.4.0'
+implementation group: 'io.github.johnnywic', name: 'bybit-java-api', version: '1.6.0'
 ```
 Furthermore, build tool, please check [sonar type central repository](https://central.sonatype.com/artifact/io.github.wuhewuhe/bybit-java-api/1.2.3)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.johnnywic</groupId>
     <artifactId>bybit-java-api</artifactId>
-    <version>1.5.0</version>
+    <version>1.6.0</version>
     <packaging>jar</packaging>
 
     <name>bybit-java-api</name>

--- a/src/main/java/com/bybit/api/client/domain/broker/request/BrokerDataRequest.java
+++ b/src/main/java/com/bybit/api/client/domain/broker/request/BrokerDataRequest.java
@@ -19,6 +19,9 @@ public class BrokerDataRequest {
     private String coin;
     private Long startTime;
     private Long endTime;
+    private String begin; // YYYYMMDD, used by /v5/broker/earnings-info
+    private String end;   // YYYYMMDD, used by /v5/broker/earnings-info
+    private String uid;   // Sub UID, used by /v5/broker/earnings-info
     private Integer limit;
     private String cursor;
     private String id; // mandatory; voucher ID in query voucher spec

--- a/src/main/java/com/bybit/api/client/impl/BybitApBrokerRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApBrokerRestClientImpl.java
@@ -21,8 +21,9 @@ public class BybitApBrokerRestClientImpl implements BybitApiBrokerRestClient {
     public Object getBrokerEarningData(BrokerDataRequest brokerDataRequest) {
         return executeSync(bybitApiService.getBrokerEarningData(
                 brokerDataRequest.getBizType() == null ? null : brokerDataRequest.getBizType().getType(),
-                brokerDataRequest.getStartTime(),
-                brokerDataRequest.getEndTime(),
+                brokerDataRequest.getBegin(),
+                brokerDataRequest.getEnd(),
+                brokerDataRequest.getUid(),
                 brokerDataRequest.getLimit(),
                 brokerDataRequest.getCursor()
         ));

--- a/src/main/java/com/bybit/api/client/impl/BybitApiAsyncBrokerRestClientImpl.java
+++ b/src/main/java/com/bybit/api/client/impl/BybitApiAsyncBrokerRestClientImpl.java
@@ -20,8 +20,9 @@ public class BybitApiAsyncBrokerRestClientImpl implements BybitApiAsyncBrokerRes
     public void getBrokerEarningData(BrokerDataRequest brokerEarningRequest, BybitApiCallback<Object> callback) {
         bybitApiService.getBrokerEarningData(
                 brokerEarningRequest.getBizType() == null ? null : brokerEarningRequest.getBizType().getType(),
-                brokerEarningRequest.getStartTime(),
-                brokerEarningRequest.getEndTime(),
+                brokerEarningRequest.getBegin(),
+                brokerEarningRequest.getEnd(),
+                brokerEarningRequest.getUid(),
                 brokerEarningRequest.getLimit(),
                 brokerEarningRequest.getCursor()
         ).enqueue(new BybitApiCallbackAdapter<>(callback));

--- a/src/main/java/com/bybit/api/client/restApi/BybitApiService.java
+++ b/src/main/java/com/bybit/api/client/restApi/BybitApiService.java
@@ -5126,33 +5126,54 @@ public interface BybitApiService {
      * Get Broker Earning
      * INFO
      * Use exchange broker master account to query
-     * The data can support up to past 6 months until T-1
-     * startTime and  endTime are either entered at the same time or not entered
+     * The data can support up to past 1 months until T-1. To extract data from over a month ago, please contact your Relationship Manager
+     * begin and end are either entered at the same time or not entered, and latest 7 days data are returned by default
      * <p>
-     * https://bybit-exchange.github.io/docs/v5/broker/earning
+     * https://bybit-exchange.github.io/docs/v5/broker/exchange-broker/exchange-earning
      *
-     * @param bizType   false	string	Business type. SPOT, DERIVATIVES, OPTIONS
-     * @param startTime false	integer	The start timestamp(ms)e
-     * @param endTime   false	integer	The end timestamp(ms)
-     * @param limit     false	integer	Limit for data size per page. [1, 1000]. Default: 1000
-     * @param cursor    false	string	Cursor. Use the nextPageCursor token from the response to retrieve the next page of the result set
+     * @param bizType false	string	Business type. SPOT, DERIVATIVES, OPTIONS, CONVERT
+     * @param begin   false	string	Begin date, in the format of YYYYMMDD, e.g, 20231201, search the data from 1st Dec 2023 00:00:00 UTC (include)
+     * @param end     false	string	End date, in the format of YYYYMMDD, e.g, 20231201, search the data before 2nd Dec 2023 00:00:00 UTC (exclude)
+     * @param uid     false	string	To get results for a specific subaccount: Enter the subaccount UID. To get results for all subaccounts: Leave the field empty
+     * @param limit   false	integer	Limit for data size per page. [1, 1000]. Default: 1000
+     * @param cursor  false	string	Cursor. Use the nextPageCursor token from the response to retrieve the next page of the result set
      * @return Response Parameters
      * Parameter	Type	Comments
-     * list	array	Object
-     * &gt; userId	string	UID
-     * &gt; bizType	string	Business type
+     * totalEarningCat	Object	Category statistics for total earning data
+     * &gt; spot	array	Object. Earning for Spot trading
+     * &gt;&gt; coin	string	Rebate coin name
+     * &gt;&gt; earning	string	Rebate amount of the coin
+     * &gt; derivatives	array	Object. Earning for Derivatives trading
+     * &gt;&gt; coin	string	Rebate coin name
+     * &gt;&gt; earning	string	Rebate amount of the coin
+     * &gt; options	array	Object. Earning for Option trading
+     * &gt;&gt; coin	string	Rebate coin name
+     * &gt;&gt; earning	string	Rebate amount of the coin
+     * &gt; convert	array	Object. Earning for Convert trading
+     * &gt;&gt; coin	string	Rebate coin name
+     * &gt;&gt; earning	string	Rebate amount of the coin
+     * &gt; total	array	Object. Sum earnings of all categories
+     * &gt;&gt; coin	string	Rebate coin name
+     * &gt;&gt; earning	string	Rebate amount of the coin
+     * details	array	Object. Detailed trading information for each sub UID and each category
+     * &gt; userId	string	Sub UID
+     * &gt; bizType	string	Business type. SPOT, DERIVATIVES, OPTIONS, CONVERT
      * &gt; symbol	string	Symbol name
-     * &gt; coin	string	Coin name. The currency of earning
-     * &gt; earning	string	Earning
+     * &gt; coin	string	Rebate coin name
+     * &gt; earning	string	Rebate amount
+     * &gt; markupEarning	string	Earning generated from markup fee rate
+     * &gt; baseFeeEarning	string	Earning generated from base fee rate
      * &gt; orderId	string	Order ID
-     * &gt; execTime	string	Execution timestamp (ms)
+     * &gt; execId	string	Trade ID
+     * &gt; execTime	string	Order execution timestamp (ms)
      * nextPageCursor	string	Refer to the cursor request parameter
      */
     @Headers(BybitApiConstants.ENDPOINT_SECURITY_TYPE_SIGNED_HEADER)
     @GET("/v5/broker/earnings-info")
     Call<Object> getBrokerEarningData(@Query("bizType") String bizType,
-                                      @Query("startTime") Long startTime,
-                                      @Query("endTime") Long endTime,
+                                      @Query("begin") String begin,
+                                      @Query("end") String end,
+                                      @Query("uid") String uid,
                                       @Query("limit") Integer limit,
                                       @Query("cursor") String cursor);
 


### PR DESCRIPTION
…o 1.6.0

- getBrokerEarningData: startTime/endTime (Long) -> begin/end (String, YYYYMMDD)
- Add uid (String) param for filtering by sub UID
- Update Javadoc and response schema (totalEarningCat, markupEarning, baseFeeEarning, execId, CONVERT bizType) per docs/v5/broker/exchange-broker
- BrokerDataRequest: add begin/end/uid fields (startTime/endTime retained for other broker endpoints)
- Bump SDK version 1.5.0 -> 1.6.0 (breaking method signature change); update README example and CHANGELOG